### PR TITLE
chore: pin workflows to go 1.26 to satisfy go.mod toolchain requirement

### DIFF
--- a/.github/workflows/ci-attest-verify.yml
+++ b/.github/workflows/ci-attest-verify.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Setup cosign
         uses: sigstore/cosign-installer@v3

--- a/.github/workflows/nightly-benchmark.yml
+++ b/.github/workflows/nightly-benchmark.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Ensure benchmark scripts are executable
         run: chmod +x scripts/benchmark.sh scripts/tamper-tests.sh

--- a/.github/workflows/public-footprint-weekly.yml
+++ b/.github/workflows/public-footprint-weekly.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Run public footprint snapshot
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Test
         run: go test ./...
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
 
       - name: Build binary
         env:
@@ -72,7 +72,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version: '1.26'
       - name: Setup cosign
         uses: sigstore/cosign-installer@v3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- CI, release, nightly-benchmark, and public-footprint workflows now pin `go-version: '1.26'` (was `'1.25'`); `go.mod` already declares `go 1.26.0`, and `GOTOOLCHAIN=local` was rejecting the older toolchain (`go: go.mod requires go >= 1.26.0`). Dockerfile builder image bumped from `golang:1.25-alpine` to `golang:1.26-alpine` for the same reason.
+
 ## [1.0.1] - 2026-02-19
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 RUN apk add --no-cache git ca-certificates
 


### PR DESCRIPTION
## Summary

- `go.mod` declares `go 1.26.0` (since v1.0.1) but the six `setup-go` pins and the Dockerfile builder image were still on Go 1.25. With `GOTOOLCHAIN=local` on `attestation-gate`, every PR fails with `go: go.mod requires go >= 1.26.0 (running go 1.25.10; GOTOOLCHAIN=local)`.
- Bumps `'1.25'` -> `'1.26'` across `ci-attest-verify.yml`, `release.yml`, `nightly-benchmark.yml`, `public-footprint-weekly.yml` plus `Dockerfile` builder stage.
- Unblocks Dependabot rollup PRs #14 (go-weekly-rollup) and #15 (actions-weekly-rollup).
- `go.mod` deliberately untouched -- this is a toolchain alignment fix, not a module floor bump.

## Test plan

- [ ] `attestation-gate` job goes green (`go test ./...` runs against Go 1.26 toolchain)
- [ ] No other CI job regresses