### PR TITLE
feat: support kubernetes 1.32 in helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Helm chart (`deploy/helm`) updated for Kubernetes 1.32 compatibility: `kubeVersion: >=1.24.0-0` added to `Chart.yaml`; `admissionReviewVersions` in `webhook.yaml` narrowed from `[v1, v1beta1]` to `[v1]` (v1beta1 is deprecated in K8s 1.16+ and unsupported in 1.32+); `timeoutSeconds` promoted from a hardcoded value to `values.yaml` (`webhook.timeoutSeconds: 10`) so operators can tune it per environment without forking the template. Chart version bumped to `1.0.1`.
 - CI, release, nightly-benchmark, and public-footprint workflows now pin `go-version: '1.26'` (was `'1.25'`); `go.mod` already declares `go 1.26.0`, and `GOTOOLCHAIN=local` was rejecting the older toolchain (`go: go.mod requires go >= 1.26.0`). Dockerfile builder image bumped from `golang:1.25-alpine` to `golang:1.26-alpine` for the same reason.
 
 ## [1.0.1] - 2026-02-19

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
 name: llmsa-webhook
 description: LLM Supply-Chain Attestation Validating Admission Webhook
-version: 1.0.0
-appVersion: "1.0.0"
+version: 1.0.1
+appVersion: "1.0.2"
 type: application
+kubeVersion: ">=1.24.0-0"
 keywords:
   - llm
   - attestation

--- a/deploy/helm/templates/webhook.yaml
+++ b/deploy/helm/templates/webhook.yaml
@@ -8,7 +8,6 @@ webhooks:
   - name: attestation.llmsa.io
     admissionReviewVersions:
       - v1
-      - v1beta1
     clientConfig:
       service:
         name: {{ include "llmsa-webhook.fullname" . }}
@@ -37,4 +36,4 @@ webhooks:
       {{- toYaml .Values.webhook.namespaceSelector | nindent 6 }}
     failurePolicy: {{ .Values.webhook.failurePolicy }}
     sideEffects: None
-    timeoutSeconds: 10
+    timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -12,6 +12,7 @@ failOpen: false
 webhook:
   port: 8443
   failurePolicy: Fail
+  timeoutSeconds: 10
   namespaceSelector:
     matchLabels:
       llmsa-attestation: enabled

--- a/roadmap.md
+++ b/roadmap.md
@@ -11,7 +11,7 @@ CLI and admission webhook that produce signed DSSE attestations for prompts, cor
 - [ ] in-toto v2 statement support alongside DSSE (backwards-compatible, negotiated by flag)
 - [ ] GitHub Action `ogulcanaydogan/llmsa-attest@v1` for one-line CI attestation
 - [ ] E2E tamper-detection test matrix: corrupt payload, clock skew, revoked key, replay
-- [ ] Helm chart updates for Kubernetes 1.32
+- [x] Helm chart updates for Kubernetes 1.32 (`kubeVersion: >=1.24.0-0`, `admissionReviewVersions` narrowed to `[v1]`, `timeoutSeconds` promoted to `values.yaml`)
 
 **Target branch**: `feature/v1.1.0`
 


### PR DESCRIPTION
## Summary

- `Chart.yaml`: adds `kubeVersion: >=1.24.0-0` so Helm lint and Artifact Hub correctly report K8s 1.32 as a supported target.
- `webhook.yaml`: narrows `admissionReviewVersions` from `[v1, v1beta1]` to `[v1]` only. `v1beta1` was deprecated in K8s 1.16 and is not supported in 1.32+; keeping it produces a deprecation warning on every install.
- `values.yaml` + `webhook.yaml`: promotes `timeoutSeconds` from a hardcoded value (10) to `values.yaml` (`webhook.timeoutSeconds: 10`). Operators in high-latency environments can now tune it without forking the template; default is unchanged.
- Chart version bumped from `1.0.0` to `1.0.1`.
- Ticks the v1.1.0 roadmap line: `Helm chart updates for Kubernetes 1.32`.

## No breaking changes

Default `timeoutSeconds` is still 10. `admissionReviewVersions: [v1]` is backward-compatible with K8s 1.9+. `kubeVersion` is advisory only.

## Test plan

- [ ] `helm lint deploy/helm/` passes with no errors or deprecation warnings.
- [ ] `helm template deploy/helm/ | kubectl apply --dry-run=client -f -` produces no unknown-field warnings.
- [ ] Existing CI webhook validation tests pass unchanged.