### PR TITLE
chore: cut v1.0.3 release with helm k8s 1.32 and go 1.26 pins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.3] - 2026-05-30
+
 ### Changed
 
 - Helm chart (`deploy/helm`) updated for Kubernetes 1.32 compatibility: `kubeVersion: >=1.24.0-0` added to `Chart.yaml`; `admissionReviewVersions` in `webhook.yaml` narrowed from `[v1, v1beta1]` to `[v1]` (v1beta1 is deprecated in K8s 1.16+ and unsupported in 1.32+); `timeoutSeconds` promoted from a hardcoded value to `values.yaml` (`webhook.timeoutSeconds: 10`) so operators can tune it per environment without forking the template. Chart version bumped to `1.0.1`.

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: llmsa-webhook
 description: LLM Supply-Chain Attestation Validating Admission Webhook
 version: 1.0.1
-appVersion: "1.0.2"
+appVersion: "1.0.3"
 type: application
 kubeVersion: ">=1.24.0-0"
 keywords:


### PR DESCRIPTION
- Promotes the populated `[Unreleased]` block to `v1.0.3`; no new code — all changes already on `main`
- Shipped work: Helm chart K8s 1.32 compat (`kubeVersion`, `admissionReviewVersions: [v1]`, `timeoutSeconds` in values.yaml, chart `1.0.1`); CI/release/nightly-benchmark/public-footprint workflows pinned to Go 1.26; Dockerfile builder bumped `golang:1.25-alpine` → `golang:1.26-alpine`
- Closes the 96-day gap since v1.0.2 (2026-02-23); `deploy/helm/Chart.yaml` `appVersion` aligned to `1.0.3`