### PR TITLE
test: add e2e tamper detection matrix for verify engine failure modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- E2E tamper-detection test matrix (`test/e2e/pipeline_test.go`): four new scenarios covering statement-hash desync, payload base64 corruption, schema violation via manually-signed invalid predicate, and signatures-cleared; exercises `ExitSignatureFail` (11) via three distinct code paths and `ExitSchemaFail` (14) which had zero test coverage previously.
+
 ## [1.0.3] - 2026-05-30
 
 ### Changed

--- a/roadmap.md
+++ b/roadmap.md
@@ -10,7 +10,7 @@ CLI and admission webhook that produce signed DSSE attestations for prompts, cor
 
 - [ ] in-toto v2 statement support alongside DSSE (backwards-compatible, negotiated by flag)
 - [ ] GitHub Action `ogulcanaydogan/llmsa-attest@v1` for one-line CI attestation
-- [ ] E2E tamper-detection test matrix: corrupt payload, clock skew, revoked key, replay
+- [x] E2E tamper-detection test matrix: statement-hash desync, payload base64 corruption, schema violation, signatures-cleared (ExitSignatureFail via three paths + ExitSchemaFail now covered); clock-skew/revoked-key/replay deferred to v1.1.0 follow-ups requiring verify engine extensions
 - [x] Helm chart updates for Kubernetes 1.32 (`kubeVersion: >=1.24.0-0`, `admissionReviewVersions` narrowed to `[v1]`, `timeoutSeconds` promoted to `values.yaml`)
 
 **Target branch**: `feature/v1.1.0`

--- a/test/e2e/pipeline_test.go
+++ b/test/e2e/pipeline_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ogulcanaydogan/llm-supply-chain-attestation/internal/attest"
+	"github.com/ogulcanaydogan/llm-supply-chain-attestation/internal/hash"
 	"github.com/ogulcanaydogan/llm-supply-chain-attestation/internal/sign"
 	"github.com/ogulcanaydogan/llm-supply-chain-attestation/internal/verify"
 )
@@ -146,6 +147,140 @@ func TestFullPipeline_SignatureCorruption(t *testing.T) {
 	}
 	if report.ExitCode != 11 {
 		t.Errorf("exit code = %d, want 11 (signature fail)", report.ExitCode)
+	}
+}
+
+func TestTamper_StatementHashDesync(t *testing.T) {
+	outDir := t.TempDir()
+	keyPath := filepath.Join(outDir, "key.pem")
+	sign.GeneratePEMPrivateKey(keyPath)
+
+	bundlePath := createAndSignAttestation(t, "prompt_attestation", configPath(t, "prompt"), outDir, keyPath)
+
+	bundle, err := sign.ReadBundle(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Metadata.StatementHash = "sha256:" + strings.Repeat("a", 64)
+	corrupted, _ := json.MarshalIndent(bundle, "", "  ")
+	os.WriteFile(bundlePath, corrupted, 0o644)
+
+	report := verify.Run(verify.Options{
+		SourcePath: outDir,
+		SchemaDir:  schemaDir(t),
+	})
+	if report.Passed {
+		t.Error("expected verify to fail after statement hash desync")
+	}
+	if report.ExitCode != verify.ExitSignatureFail {
+		t.Errorf("exit code = %d, want %d (ExitSignatureFail)", report.ExitCode, verify.ExitSignatureFail)
+	}
+}
+
+func TestTamper_PayloadBase64Corruption(t *testing.T) {
+	outDir := t.TempDir()
+	keyPath := filepath.Join(outDir, "key.pem")
+	sign.GeneratePEMPrivateKey(keyPath)
+
+	bundlePath := createAndSignAttestation(t, "prompt_attestation", configPath(t, "prompt"), outDir, keyPath)
+
+	bundle, err := sign.ReadBundle(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Envelope.Payload = "!!!not-valid-base64==="
+	corrupted, _ := json.MarshalIndent(bundle, "", "  ")
+	os.WriteFile(bundlePath, corrupted, 0o644)
+
+	report := verify.Run(verify.Options{
+		SourcePath: outDir,
+		SchemaDir:  schemaDir(t),
+	})
+	if report.Passed {
+		t.Error("expected verify to fail after payload base64 corruption")
+	}
+	if report.ExitCode != verify.ExitSignatureFail {
+		t.Errorf("exit code = %d, want %d (ExitSignatureFail)", report.ExitCode, verify.ExitSignatureFail)
+	}
+}
+
+func TestTamper_SchemaViolation(t *testing.T) {
+	outDir := t.TempDir()
+	keyPath := filepath.Join(outDir, "key.pem")
+	sign.GeneratePEMPrivateKey(keyPath)
+
+	// Statement that satisfies the base statement schema but fails the
+	// predicate-specific schema: prompt_attestation requires prompt_bundle_digest
+	// (and others) which are all absent from this empty predicate.
+	stmt := map[string]any{
+		"schema_version":   "1.0.0",
+		"statement_id":     "test-schema-fail",
+		"attestation_type": "prompt_attestation",
+		"predicate_type":   "https://llmsa.dev/attestation/prompt/v1",
+		"generated_at":     "2026-06-02T00:00:00Z",
+		"generator":        map[string]any{"name": "test", "version": "0.0.0", "git_sha": "abc"},
+		"subject":          []any{},
+		"predicate":        map[string]any{},
+		"privacy":          map[string]any{"mode": "hash_only"},
+	}
+
+	canonical, err := hash.CanonicalJSON(stmt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signer, err := sign.NewPEMSigner(keyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	material, err := signer.Sign(canonical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle, err := sign.CreateBundle(stmt, material)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundlePath := filepath.Join(outDir, "prompt_attestation.bundle.json")
+	if err := sign.WriteBundle(bundlePath, bundle); err != nil {
+		t.Fatal(err)
+	}
+
+	report := verify.Run(verify.Options{
+		SourcePath: outDir,
+		SchemaDir:  schemaDir(t),
+	})
+	if report.Passed {
+		t.Error("expected verify to fail on schema violation")
+	}
+	if report.ExitCode != verify.ExitSchemaFail {
+		t.Errorf("exit code = %d, want %d (ExitSchemaFail)", report.ExitCode, verify.ExitSchemaFail)
+	}
+}
+
+func TestTamper_SignaturesCleared(t *testing.T) {
+	outDir := t.TempDir()
+	keyPath := filepath.Join(outDir, "key.pem")
+	sign.GeneratePEMPrivateKey(keyPath)
+
+	bundlePath := createAndSignAttestation(t, "prompt_attestation", configPath(t, "prompt"), outDir, keyPath)
+
+	bundle, err := sign.ReadBundle(bundlePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bundle.Envelope.Signatures = nil
+	corrupted, _ := json.MarshalIndent(bundle, "", "  ")
+	os.WriteFile(bundlePath, corrupted, 0o644)
+
+	report := verify.Run(verify.Options{
+		SourcePath: outDir,
+		SchemaDir:  schemaDir(t),
+	})
+	if report.Passed {
+		t.Error("expected verify to fail after signatures cleared")
+	}
+	if report.ExitCode != verify.ExitSignatureFail {
+		t.Errorf("exit code = %d, want %d (ExitSignatureFail)", report.ExitCode, verify.ExitSignatureFail)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Four new E2E scenarios in `test/e2e/pipeline_test.go` exercise three code paths in `signature_verify.go` that were previously untested: statement-hash desync (line 33 hash mismatch), payload base64 corruption (line 29 decode failure), and signatures-cleared (line 24 empty-slice guard); plus `ExitSchemaFail` (14) which had zero coverage before this PR
- No production code changed — pure test coverage addition
- Advances the v1.1.0 roadmap tamper-detection item; clock-skew, revoked-key, and replay scenarios are explicitly deferred pending verify engine extensions (`ExitPolicyFail` (13) is only reachable via the `check-policy` CLI command, not via `verify.Run()`)

## Test plan

- [ ] `go test -tags=e2e -v ./test/e2e/ -run TestTamper` — four new tests pass alongside existing six
- [ ] `go test -tags=e2e -v ./test/e2e/` — full E2E suite still green (no regression)
- [ ] `roadmap.md` shows `[x]` on tamper-detection matrix line with scope annotation