### PR TITLE
fix(release): stop checksums.txt listing its own checksum

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -82,7 +82,8 @@ jobs:
             echo "checksums.txt not found in release assets"
             exit 1
           fi
-          sha256sum -c checksums.txt
+          # checksums.txt cannot list its own checksum, so verify every entry except itself.
+          grep -vE '[[:space:]]checksums\.txt$' checksums.txt | sha256sum -c -
 
       - name: Verify cosign signatures
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Generate checksums
         run: |
           rm -f dist/checksums.txt
-          (cd dist && find . -maxdepth 1 -type f ! -name '*.sig' ! -name '*.pem' -print0 | sort -z | xargs -0 sha256sum | sed 's|^\./||' > checksums.txt)
+          (cd dist && find . -maxdepth 1 -type f ! -name '*.sig' ! -name '*.pem' ! -name 'checksums.txt' -print0 | sort -z | xargs -0 sha256sum | sed 's|^\./||' > checksums.txt)
 
       - name: Install syft
         uses: anchore/sbom-action/download-syft@v0


### PR DESCRIPTION
## Problem
`release-verify` failed on every run (and kept `completion-daily-health` red) with:
```
/checksums.txt: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
```
All other assets verified OK.

## Cause
In `release.yml`, the `> checksums.txt` redirect creates the (empty) file before `find` scans `dist/`, so `find` includes `checksums.txt` itself and records a self-hash that can never match.

## Fix
- `release.yml`: exclude `checksums.txt` from the `find` that feeds `sha256sum` (clean checksums for future releases).
- `release-verify.yml`: skip the `checksums.txt` self-entry when running `sha256sum -c` (a checksum file cannot contain its own checksum), so existing releases like v1.0.3 verify too.