### PR TITLE
fix(release-verify): match checksums.txt entry with ./ path prefix

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -83,7 +83,7 @@ jobs:
             exit 1
           fi
           # checksums.txt cannot list its own checksum, so verify every entry except itself.
-          grep -vE '[[:space:]]checksums\.txt$' checksums.txt | sha256sum -c -
+          grep -vE '[[:space:]./]checksums\.txt$' checksums.txt | sha256sum -c -
 
       - name: Verify cosign signatures
         run: |


### PR DESCRIPTION
Follow-up to the checksums self-reference fix. Release `checksums.txt` stores names as `./<file>`, so the self line is `./checksums.txt`. The earlier exclusion regex (`[[:space:]]checksums\.txt$`) didn't match because of the `./` prefix, so v1.0.3 still failed on the stale empty-file self-hash. Broaden the boundary class to `[[:space:]./]`.