### PR TITLE
feat(release-verify): preflight GitHub API access check

### DIFF
--- a/.github/workflows/release-verify.yml
+++ b/.github/workflows/release-verify.yml
@@ -50,6 +50,40 @@ jobs:
       - name: Setup cosign
         uses: sigstore/cosign-installer@v3
 
+      - name: Validate GitHub API access (preflight)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Fail fast with an actionable message if the workflow token cannot
+          # reach the GitHub API or the resolved release, before the retrying
+          # asset download below spends three attempts on an auth problem.
+          tag="${{ steps.resolve.outputs.tag }}"
+          if [[ -z "${GH_TOKEN}" ]]; then
+            echo "::error::release-verify preflight: GH_TOKEN is empty"
+            echo "Likely cause: job permissions missing 'contents: read' or GH_TOKEN not wired to \${{ github.token }}."
+            echo "Remediation: restore 'permissions: contents: read' on the job and re-run the workflow."
+            exit 1
+          fi
+          if ! gh auth status >/dev/null 2>&1; then
+            echo "::error::release-verify preflight: gh CLI is not authenticated"
+            echo "Likely cause: GITHUB_TOKEN expired, revoked, or lacks 'contents: read' scope."
+            echo "Remediation: check 'gh auth status' locally with the same token, confirm workflow permissions, then re-run."
+            exit 1
+          fi
+          if ! gh api "/repos/${GITHUB_REPOSITORY}" --jq '.full_name' >/dev/null 2>&1; then
+            echo "::error::release-verify preflight: GitHub API request failed for ${GITHUB_REPOSITORY}"
+            echo "Likely cause: token lacks repo read access, transient API outage, or secondary rate limiting."
+            echo "Remediation: verify 'contents: read' permission and re-run; if rate limited, wait and re-run."
+            exit 1
+          fi
+          if ! gh release view "${tag}" -R "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            echo "::error::release-verify preflight: release '${tag}' is not readable"
+            echo "Likely cause: tag does not exist, the release is not published yet, or insufficient read scope."
+            echo "Remediation: confirm with 'gh release list -R ${GITHUB_REPOSITORY}' and re-run with a valid published tag."
+            exit 1
+          fi
+          echo "preflight OK: authenticated and release '${tag}' is reachable"
+
       - name: Download release assets
         env:
           GH_TOKEN: ${{ github.token }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,3 +4,33 @@
 - `go test ./...` passes.
 - CI `attestation-gate` passes.
 - Verify report artifacts published (`verify.json`, `verify.md`).
+
+## release-verify auth troubleshooting
+
+The `release-verify` workflow runs a **preflight** step ("Validate GitHub API
+access") before downloading release assets. It probes the workflow token, the
+GitHub API, and the resolved release so that auth problems fail fast with an
+actionable message instead of surfacing as opaque "failed to download release
+assets after retries" errors three retries later.
+
+Common failure modes and remediation:
+
+| Preflight error | Likely cause | Remediation |
+| --- | --- | --- |
+| `GH_TOKEN is empty` | Job lost `permissions: contents: read`, or `GH_TOKEN` not wired to `${{ github.token }}` | Restore `permissions: contents: read` on the job and re-run. |
+| `gh CLI is not authenticated` | `GITHUB_TOKEN` expired/revoked or missing `contents: read` scope | Run `gh auth status` locally with the same token, confirm workflow permissions, re-run. |
+| `GitHub API request failed for <repo>` | Token lacks repo read access, transient API outage, or secondary rate limiting | Verify `contents: read`; if rate limited, wait and re-run. |
+| `release '<tag>' is not readable` | Tag does not exist, release not published yet, or insufficient read scope | `gh release list -R <repo>` to confirm, re-run with a valid published tag. |
+
+Local debugging:
+
+```bash
+# Confirm the token the workflow uses can see the release
+gh auth status
+gh api "/repos/<owner>/<repo>" --jq '.full_name'
+gh release view "<tag>" -R "<owner>/<repo>"
+```
+
+The preflight only validates access; the real integrity gates (`checksums.txt`
+verification and `cosign verify-blob` signature/identity checks) still run and
+still fail the workflow on any mismatch.


### PR DESCRIPTION
## Problem
`release-verify` downloads release assets in a three-attempt retry loop. When the real cause is an auth/access problem — empty token, expired `GITHUB_TOKEN`, missing `contents: read` scope, or a tag that is not published yet — the retries waste time and end with an opaque `failed to download release assets after retries` message that gives no remediation.

## Change
Add a **preflight** step ("Validate GitHub API access") that runs after tag resolution and before the asset download. It checks, in order:
1. `GH_TOKEN` is non-empty
2. `gh auth status` (CLI is authenticated)
3. `gh api /repos/$REPO` (API reachable with the token)
4. `gh release view <tag>` (the resolved release is readable)

Each failure emits an actionable `::error::` annotation with a likely cause and remediation step. `RELEASE.md` gains a matching "release-verify auth troubleshooting" section (failure table + local debug commands).

## Acceptance criteria (issue #6)
- [x] release-verify confirms API access before asset download
- [x] Auth failure path reports an actionable error message
- [x] Workflow remains green for tag and `workflow_dispatch` paths (preflight passes when the token is valid and the release exists)
- [x] Failure diagnostics + remediation documented in release docs

The existing `checksums.txt` verification and `cosign verify-blob` signature/identity gates are unchanged.

Fixes #6