### PR TITLE
docs: add go install instructions and pkg.go.dev badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ![Tamper Tests](https://img.shields.io/badge/Tamper%20Tests-20%20Cases-red)
 ![License](https://img.shields.io/badge/License-Apache%202.0-blue)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/12168/badge)](https://www.bestpractices.dev/projects/12168)
+[![Go Reference](https://pkg.go.dev/badge/github.com/ogulcanaydogan/llm-supply-chain-attestation.svg)](https://pkg.go.dev/github.com/ogulcanaydogan/llm-supply-chain-attestation)
 
 ---
 
@@ -292,6 +293,17 @@ flowchart LR
 **Signature/Bundle Tampering (T11–T14)**: Signature corruption, public key substitution, statement hash manipulation, and signature removal — all caught by DSSE verification (exit 11).
 
 **Schema and Chain Integrity (T15–T20)**: Missing required predicate fields, invalid timestamps, malformed digests, incomplete dependency chains, and dangling references — all rejected by schema and chain validation (exit 14).
+
+## Install
+
+Install the `llmsa` CLI directly with the Go toolchain (Go 1.25+):
+
+```bash
+go install github.com/ogulcanaydogan/llm-supply-chain-attestation/cmd/llmsa@latest
+```
+
+This places the `llmsa` binary in `$(go env GOPATH)/bin`. Prebuilt binaries and
+checksums are also attached to each [GitHub Release](https://github.com/ogulcanaydogan/LLM-Supply-Chain-Attestation/releases).
 
 ## Quick Start
 


### PR DESCRIPTION
## What
Adds an **Install** section documenting `go install github.com/ogulcanaydogan/llm-supply-chain-attestation/cmd/llmsa@latest` and a pkg.go.dev reference badge.

## Why
The module is fetchable via the Go proxy but the README had no one-line install path for the `llmsa` CLI and no pkg.go.dev link, so adopters had to clone and build from source. A `go install` line makes the tool installable in one command and surfaces the API docs.

## How
Doc-only change: new `## Install` section before Quick Start + one badge in the header. No code touched.