### PR TITLE
test: cover trailing-wildcard prefix fallback in path matcher

### DIFF
--- a/internal/attest/service_test.go
+++ b/internal/attest/service_test.go
@@ -47,6 +47,29 @@ func TestMatchesNoMatch(t *testing.T) {
 	}
 }
 
+// A trailing "*" pattern falls back to a prefix match that DOES cross "/"
+// (filepath.Match's "*" does not). So "data*" matches "data/nested/file.txt".
+// Note: policy/yaml match() has no such fallback, so the same pattern behaves
+// differently in policy triggers vs. attestation-type inference.
+func TestMatchesTrailingWildcardCrossesDirectory(t *testing.T) {
+	if !matches("data/nested/file.txt", "data*") {
+		t.Error("expected data/nested/file.txt to match data* via prefix fallback")
+	}
+}
+
+func TestMatchesTrailingWildcardPrefixMismatch(t *testing.T) {
+	if matches("metrics/app.txt", "logs*") {
+		t.Error("expected metrics/app.txt NOT to match logs* (prefix differs)")
+	}
+}
+
+func TestMatchesLiteralNonMatch(t *testing.T) {
+	// No "/**", no trailing "*", and filepath.Match fails -> final false branch.
+	if matches("a/b.txt", "x/y.txt") {
+		t.Error("expected a/b.txt NOT to match literal pattern x/y.txt")
+	}
+}
+
 // --- inferAttestationTypes() ---
 
 func TestInferAttestationTypesSingleMatch(t *testing.T) {


### PR DESCRIPTION
## What
Covers the previously-untested trailing-`*` fallback branch in `matches()` (`internal/attest/service.go`), taking the function from 70% to 100%.

## Why
`matches()` maps changed git paths to attestation types. Its `/**` and standard-glob branches were tested, but the trailing-`*` prefix fallback (which, unlike `filepath.Match`, crosses `/`) had no coverage. That fallback is the branch responsible for `data*` matching `data/nested/file.txt`.

## How
White-box tests (stdlib `testing`, no testify, mirroring the existing `service_test.go` style):
- `data*` matches `data/nested/file.txt` (prefix fallback that crosses `/`).
- `logs*` does not match `metrics/app.txt` (prefix mismatch → false).
- a literal pattern with no wildcard and no match → final `false` branch.

A comment documents that this fallback intentionally crosses `/`, and that `policy/yaml` `match()` has no such fallback (so the same glob behaves differently in policy triggers vs. attestation-type inference) — see the follow-up issue.

## Verification
`go test ./internal/attest/` passes; `matches` now 100%. `gofmt`, `go vet` clean; `golangci-lint --new-from-rev=main` reports 0 new issues. No production code changed.