### PR TITLE
test: cover canonical JSON writer error and default branches

### DIFF
--- a/internal/hash/writecanonical_test.go
+++ b/internal/hash/writecanonical_test.go
@@ -333,5 +333,68 @@ func TestDigestTreeNonexistentRoot(t *testing.T) {
 	}
 }
 
+// --- writeCanonical: array element separator write error ---
+
+func TestWriteCanonicalArrayCommaWriteError(t *testing.T) {
+	// "[" (1) + "\"a\"" (3) = 4 bytes, then fail on the "," before the 2nd element.
+	w := &failWriter{limit: 4}
+	err := writeCanonical(w, []any{"a", "b"})
+	if err == nil {
+		t.Fatal("expected write error on array element separator")
+	}
+}
+
+// --- writeCanonical: map key / value / separator write errors ---
+
+func TestWriteCanonicalMapKeyWriteError(t *testing.T) {
+	// "{" (1) written, then fail while writing the key bytes.
+	w := &failWriter{limit: 1}
+	err := writeCanonical(w, map[string]any{"k": "v"})
+	if err == nil {
+		t.Fatal("expected write error on map key")
+	}
+}
+
+func TestWriteCanonicalMapValueWriteError(t *testing.T) {
+	// "{" (1) + "\"k\"" (3) + ":" (1) = 5 bytes, then fail on the value.
+	w := &failWriter{limit: 5}
+	err := writeCanonical(w, map[string]any{"k": "v"})
+	if err == nil {
+		t.Fatal("expected write error on map value")
+	}
+}
+
+func TestWriteCanonicalMapCommaWriteError(t *testing.T) {
+	// "{" + "\"a\"" + ":" + "\"1\"" = 8 bytes, then fail on the "," before the 2nd entry.
+	w := &failWriter{limit: 8}
+	err := writeCanonical(w, map[string]any{"a": "1", "b": "2"})
+	if err == nil {
+		t.Fatal("expected write error on map entry separator")
+	}
+}
+
+// --- writeCanonical: default branch reached directly (non-normalized types) ---
+
+func TestWriteCanonicalDefaultBranchInt(t *testing.T) {
+	// Calling writeCanonical directly with an int hits the default case, which
+	// marshals and re-normalizes the value through json.Number.
+	var buf bytes.Buffer
+	if err := writeCanonical(&buf, 42); err != nil {
+		t.Fatal(err)
+	}
+	if buf.String() != "42" {
+		t.Fatalf("expected 42, got %q", buf.String())
+	}
+}
+
+func TestWriteCanonicalDefaultBranchMarshalError(t *testing.T) {
+	// A channel cannot be marshaled; the default case must surface the error.
+	var buf bytes.Buffer
+	err := writeCanonical(&buf, make(chan int))
+	if err == nil {
+		t.Fatal("expected marshal error in default branch")
+	}
+}
+
 // We cannot import from io in the scope, ensure io is used properly
 var _ io.Writer = (*failWriter)(nil)


### PR DESCRIPTION
## What
Add six focused cases to `internal/hash/writecanonical_test.go`, lifting `writeCanonical` from **73% to 95%** (package `internal/hash` 83% → 93%).

## Why
Canonical JSON is what gets hashed and signed, so its serializer's branches matter. These are reachable paths the existing failWriter-based suite had not yet reached:
- **array element separator** write failure (existing test only reached the element write)
- **map key**, **map value**, and **map entry separator** write failures
- the **default case** reached by passing a non-normalized Go value directly to `writeCanonical` (an `int`, and an unmarshalable `chan int` for the marshal-error path) — the prior default-branch test routed through `CanonicalJSON`, which normalizes structs to `map[string]any` before the writer runs, so the default arm never executed

The handful of still-uncovered lines are genuinely unreachable defensive guards (json.Marshal of a Go string / map key cannot fail; re-decoding freshly marshaled bytes cannot fail), so they are intentionally left rather than forced.

## Verification
- `go test ./...` passes; `go vet` and `gofmt` clean
- `writeCanonical` 73.2% → **94.6%**, `internal/hash` 82.9% → **93.2%**